### PR TITLE
make frontier-squid service spec fully configurable

### DIFF
--- a/frontier-squid/templates/service.yaml
+++ b/frontier-squid/templates/service.yaml
@@ -4,13 +4,6 @@ metadata:
   name: {{ include "frontier-squid.fullname" . }}
   labels:
     {{- include "frontier-squid.labels" . | nindent 4 }}
-spec:
-  type: ClusterIP
-  ports:
-    - port: 3128
-      targetPort: 3128
-      protocol: TCP
-      name: squid
+spec: {{- .Values.service | toYaml | trim | nindent 2 }}
   selector:
     {{- include "frontier-squid.selectorLabels" . | nindent 4 }}
-

--- a/frontier-squid/values.yaml
+++ b/frontier-squid/values.yaml
@@ -70,3 +70,11 @@ config:
     diskMaxSize: "1 GB"         # Maximum object size to be cached on disk
     memorySpace: "256 MB"
     memoryMaxSize: "32 KB"      # Maximum object size to be cached in memory
+
+service:
+  type: ClusterIP
+  ports:
+    - port: 3128
+      targetPort: 3128
+      protocol: TCP
+      name: squid


### PR DESCRIPTION
Move the service config to values; making the service definition fully arbitrarily configurable, without changing the default.
This allows users to e.g. change to a nodePort service or modify other aspects as needed.

In my particular case, the CVMFS client is installed on the k8s nodes, not running in pods, so cluster DNS can not be used to discover the squid service.
However the nodes can access the clusterIP range, so it just needs to be a fixed clusterIP.
With this PR I can just add this to my values.yaml
```
service:
  clusterIP: 10.233.3.128
```
and then put `http://10.233.3.128:3128`  in my /etc/cvmfs/default.local on the nodes.
@ebocchi 