### PR TITLE
send squid access logs to stdout

### DIFF
--- a/frontier-squid/templates/configmap.yaml
+++ b/frontier-squid/templates/configmap.yaml
@@ -29,7 +29,7 @@ data:
     {{- end }}
 
     # Logs
-    access_log daemon:/var/log/squid/access.log squid
+    access_log stdio:/dev/stdout rotate=0
     cache_log /var/log/squid/cache.log
     strip_query_terms off
 


### PR DESCRIPTION
Change the access_log destination,  fix https://github.com/sciencebox/charts/issues/67

The cache log already goes both to stdout (because of `squid -N`) and to cache.log which is good and doesn't need to be changed. It usually only logs at startup so doesn't produce much volume. This way the cache log output can be seen in the normal way, and also if squid has been running for awhile and stdout is filled with access logs, you can still get the cache log from /var/log if needed.