### PR TITLE
frontier-squid: run as unprivileged user without change to YAML

### DIFF
--- a/frontier-squid/templates/deployment.yaml
+++ b/frontier-squid/templates/deployment.yaml
@@ -35,10 +35,6 @@ spec:
                 {{- end }}
               topologyKey: "kubernetes.io/hostname"
       {{- end }}
-      securityContext:
-        runAsUser: 5000
-        runAsGroup: 5000
-        fsGroup: 5000
       initContainers:
         - name: frontier-squid-init0-makedirs
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
This reverts commit 111fd942b09f323ea927862b73cef0c60b4e9252.

It should be better to address this purely in the dockerfile without changing the deployment YAML.
Depends on new container image built with https://github.com/sciencebox/frontier-squid/commit/c940aa731ac81d205e62dd6c286018736561b02c (no rush).

Related to https://github.com/sciencebox/charts/issues/61
See discussion https://github.com/sciencebox/charts/pull/62