### PR TITLE
allow configurable ACL activation

### DIFF
--- a/frontier-squid/templates/configmap.yaml
+++ b/frontier-squid/templates/configmap.yaml
@@ -119,10 +119,9 @@ data:
     # Allow directives
     http_access allow localhost
     http_access allow localhost manager
-    http_access allow stratum_ones
-    http_access allow osgstorage
-    http_access allow misc
-    http_access allow grid_ca
+    {{- range .Values.httpAccessAllow }}
+    http_access allow {{ . }}
+    {{- end }}
     
     # Deny directives
     http_access deny !safe_ports

--- a/frontier-squid/values.yaml
+++ b/frontier-squid/values.yaml
@@ -86,6 +86,15 @@ config:
     memoryMaxSize: "32 KB"      # Maximum object size to be cached in memory
 
 #
+# List of squid ACLs to enable via 'http_access allow' (see configmap for ACL definitions)
+#
+httpAccessAllow:
+  - stratum_ones
+  - osgstorage
+  - misc
+  - grid_ca
+
+#
 # Network Service Specs
 #   Docs: https://kubernetes.io/docs/concepts/services-networking/service/
 #


### PR DESCRIPTION
Allow ACLs to be selectively enabled. Confirmed that default result is the same as before:
```
      # Allow directives
      http_access allow localhost
      http_access allow localhost manager
      http_access allow stratum_ones
      http_access allow osgstorage
      http_access allow misc
      http_access allow grid_ca
```
and if I modify the list to just stratum_ones:
```
      # Allow directives
      http_access allow localhost
      http_access allow localhost manager
      http_access allow stratum_ones
```
