### PR TITLE
frontier-squid: make a backup readiness probe URL

### DIFF
--- a/frontier-squid/templates/deployment.yaml
+++ b/frontier-squid/templates/deployment.yaml
@@ -68,15 +68,8 @@ spec:
         {{- if .Values.probes.readiness }}
         readinessProbe:
           exec:
-            command:
-              - /usr/bin/curl
-              - --silent
-              - --fail
-              - --output
-              - /dev/null
-              - --proxy
-              - http://127.0.0.1:3128
-              - {{ .Values.probes.readinessUrl }}
+            command: ["/bin/sh", "-c"]
+            args: ["/usr/bin/curl --silent --fail --output /dev/null --proxy http://127.0.0.1:3128 {{ .Values.probes.readinessUrl1 }} || /usr/bin/curl --silent --fail --output /dev/null --proxy http://127.0.0.1:3128 {{ .Values.probes.readinessUrl2 }}"]
           initialDelaySeconds: 5
           periodSeconds: 30
         {{- end }}

--- a/frontier-squid/templates/deployment.yaml
+++ b/frontier-squid/templates/deployment.yaml
@@ -74,6 +74,7 @@ spec:
             - "/usr/bin/curl --silent --fail --output /dev/null --proxy http://127.0.0.1:3128 {{ .Values.probes.readinessUrl1 }} || /usr/bin/curl --silent --fail --output /dev/null --proxy http://127.0.0.1:3128 {{ .Values.probes.readinessUrl2 }}"
           initialDelaySeconds: 5
           periodSeconds: 30
+          timeoutSeconds: 5
         {{- end }}
         volumeMounts:
           - name: frontier-squid-config

--- a/frontier-squid/templates/deployment.yaml
+++ b/frontier-squid/templates/deployment.yaml
@@ -68,8 +68,10 @@ spec:
         {{- if .Values.probes.readiness }}
         readinessProbe:
           exec:
-            command: ["/bin/sh", "-c"]
-            args: ["/usr/bin/curl --silent --fail --output /dev/null --proxy http://127.0.0.1:3128 {{ .Values.probes.readinessUrl1 }} || /usr/bin/curl --silent --fail --output /dev/null --proxy http://127.0.0.1:3128 {{ .Values.probes.readinessUrl2 }}"]
+            command:
+            - "/bin/sh"
+            - "-c"
+            - "/usr/bin/curl --silent --fail --output /dev/null --proxy http://127.0.0.1:3128 {{ .Values.probes.readinessUrl1 }} || /usr/bin/curl --silent --fail --output /dev/null --proxy http://127.0.0.1:3128 {{ .Values.probes.readinessUrl2 }}"
           initialDelaySeconds: 5
           periodSeconds: 30
         {{- end }}

--- a/frontier-squid/values.yaml
+++ b/frontier-squid/values.yaml
@@ -56,16 +56,17 @@ customLabels:
 #   Checks every 30 seconds whether the readinessUrl is reachable using the squid in the pod as proxy.
 #   If unreachable, the failing frontier-squid pod will be removed from the service load-balanced alias.
 #
-#   Readiness Url:
-#     The URL used by the readiness probe to check the squid in the pod works as expected.
-#     Defaults to 'http://cvmfs-stratum-one.cern.ch/cvmfs/info/v1/meta.json'
+#   Readiness Urls:
+#     The URLs used by the readiness probe to check the squid in the pod works as expected.
+#     Two URLs are used as backups for each other, to avoid marking the pods unready if one external server is unavailable.
 #
 # Default: All probes enabled.
 #
 probes:
   liveness: true
   readiness: true
-  readinessUrl: 'http://cvmfs-stratum-one.cern.ch/cvmfs/info/v1/meta.json'
+  readinessUrl1: 'http://cvmfs-stratum-one.cern.ch/cvmfs/info/v1/meta.json'
+  readinessUrl2: 'http://cvmfs.fnal.gov/cvmfs/info/v1/meta.json'
 
 #
 # Squid configuration


### PR DESCRIPTION
With a readinessprobe relying on one external server, failure of that server would cause an outage of the whole squid deployment. It can be more redundant by using multiple probe URLs.

The command could be shortened by using `curl -K configfile`  and putting the curl args in a file, but that would require a separate configmap, volume mount etc.

Also increase the probe timeout as the default (1s)  could be a bit short if there is a bit more network latency or squid busyness than usual, and there are 2 curl commands to run now.
