### PR TITLE
frontier-squid: add frontier ACLs

### DIFF
--- a/frontier-squid/templates/configmap.yaml
+++ b/frontier-squid/templates/configmap.yaml
@@ -82,6 +82,12 @@ data:
     acl stratum_ones url_regex ^http://cvmfs02.grid.sinica.edu.tw
     acl stratum_ones url_regex ^http://cvmfs-stratum-one.ihep.ac.cn
 
+    # ACL for ATLAS Frontier (for reference see ATLAS_FRONTIER from frontier-squid package)
+    acl atlas_frontier dstdom_regex ^(frontier.*\.racf\.bnl\.gov|atlas.*frontier.*\.cern\.ch|cc.*\.in2p3\.fr|lcg.*\.gridpp\.rl\.ac\.uk|(.*frontier.*|tier1nfs)\.triumf\.ca|atlas.*frontier\.openhtc\.io)$
+
+    # ACL for CMS Frontier (for reference see CMS_FRONTIER from frontier-squid package)
+    acl cms_frontier dstdom_regex ^(cmsfrontier.*\.cern\.ch|cms.*frontier\.openhtc\.io)$
+
     # ACL fragment for osgstorage
     acl osgstorage url_regex ^http://osgxroot.usatlas.bnl.gov
     acl osgstorage url_regex ^http://xrd-cache-1.t2.ucsd.edu

--- a/frontier-squid/values.yaml
+++ b/frontier-squid/values.yaml
@@ -94,6 +94,8 @@ httpAccessAllow:
   - osgstorage
   - misc
   - grid_ca
+#  - atlas_frontier
+#  - cms_frontier
 
 #
 # Network Service Specs


### PR DESCRIPTION
fixes https://github.com/sciencebox/charts/issues/77

Defines the ACLs, copied from frontier-squid package, but does not enable them by default.