### PR TITLE
frontier-squid: don't block ports considered safe

### DIFF
--- a/frontier-squid/templates/configmap.yaml
+++ b/frontier-squid/templates/configmap.yaml
@@ -55,9 +55,16 @@ data:
 
     # ACL fragments
     # ACL fragment for safe_ports: Will deny not safe_ports
-    acl safe_ports port 80
-    acl safe_ports port 3128
-    acl safe_ports port 8000
+    acl safe_ports port 80		# http
+    acl safe_ports port 21		# ftp
+    acl safe_ports port 443		# https
+    acl safe_ports port 70		# gopher
+    acl safe_ports port 210		# wais
+    acl safe_ports port 1025-65535	# unregistered ports - including 8000 for CVMFS/Frontier
+    acl safe_ports port 280		# http-mgmt
+    acl safe_ports port 488		# gss-http
+    acl safe_ports port 591		# filemaker
+    acl safe_ports port 777		# multiling http
     
     # ACL fragment for ssl_ports: Will deny connect method for not ssl_ports
     acl CONNECT method connect

--- a/frontier-squid/templates/configmap.yaml
+++ b/frontier-squid/templates/configmap.yaml
@@ -56,6 +56,7 @@ data:
     # ACL fragments
     # ACL fragment for safe_ports: Will deny not safe_ports
     acl safe_ports port 80
+    acl safe_ports port 3128
     acl safe_ports port 8000
     
     # ACL fragment for ssl_ports: Will deny connect method for not ssl_ports

--- a/frontier-squid/templates/configmap.yaml
+++ b/frontier-squid/templates/configmap.yaml
@@ -60,7 +60,7 @@ data:
     acl safe_ports port 443		# https
     acl safe_ports port 70		# gopher
     acl safe_ports port 210		# wais
-    acl safe_ports port 1025-65535	# unregistered ports - including 8000 for CVMFS/Frontier
+    acl safe_ports port 1025-65535	# unregistered ports: including 3128 for local squidclient mgmt, 8000 for CVMFS/Frontier
     acl safe_ports port 280		# http-mgmt
     acl safe_ports port 488		# gss-http
     acl safe_ports port 591		# filemaker


### PR DESCRIPTION
The chart is very conservative in only allowing ports 80 and 8000.
Upstream squid allows all high ports among various others:
```
acl Safe_ports port 1025-65535	# unregistered ports
```

The TRIUMF frontier server is different from all the other frontier servers; it listens on port 3128 (squid, used to be a reverse proxy but is now operating as an open forwarding proxy) so it gets blocked. 

Aside from fixing the issue for TRIUMF Frontier, squid is sometimes used as a reverse proxy so this will allow the local squid cache to access upstream reverse proxy squid caches.

@ebocchi can we get this into a new prod chart release please? 
