### PR TITLE
Fix: Removed typo in ingress template for ocis

### DIFF
--- a/ocis/templates/ingress.yaml
+++ b/ocis/templates/ingress.yaml
@@ -45,9 +45,9 @@ metadata:
   name: {{ $fullName }}-https
   labels:
     {{- include "ocis.labels" . | nindent 4 }}
-  {{- if .Values.ingress.annotation }}
+  {{- if .Values.ingress.annotations }}
   annotations:
-    {{- range $key, $value := .Values.ingress.annotation }}
+    {{- range $key, $value := .Values.ingress.annotations }}
     {{ $key }}: {{ tpl $value $ | quote }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
In the ingress template for ocis, there are three ingresses defined.
Annotations supplied in the values file will not be populated to the second ingress, because of a missing trailing s.