### PR TITLE
frontier-squid: allow further configuration of cache_dir

### DIFF
--- a/frontier-squid/Chart.yaml
+++ b/frontier-squid/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 #
 name: frontier-squid
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: 4.17-2.1
 #
 description: Frontier Squid cache for CVMFS clients

--- a/frontier-squid/README.md
+++ b/frontier-squid/README.md
@@ -55,6 +55,7 @@ Chartmuseum format is deprecated. The last chart tag published in chartmuseum fo
 | config.cache.diskDirectory | string | `"/var/cache/squid"` |  |
 | config.cache.diskMaxSize | string | `"1 GB"` |  |
 | config.cache.diskSpace | int | `10000` | in MB |
+| config.cache.cache_dir | string | `"cache_dir ufs {{ $.Values.config.cache.diskDirectory }} {{ $.Values.config.cache.diskSpace }} 16 256"` | Allows full configurability of the `cache_dir` parameter. |
 | config.cache.memoryMaxSize | string | `"32 KB"` | Maximum object size to be cached in memory |
 | config.cache.memorySpace | string | `"256 MB"` | Maximum object size to be cached on disk |
 | config.cache.minSize | string | `"0 KB"` | Applies to both in-memory and on disk caches |

--- a/frontier-squid/README.md
+++ b/frontier-squid/README.md
@@ -55,7 +55,6 @@ Chartmuseum format is deprecated. The last chart tag published in chartmuseum fo
 | config.cache.diskDirectory | string | `"/var/cache/squid"` |  |
 | config.cache.diskMaxSize | string | `"1 GB"` |  |
 | config.cache.diskSpace | int | `10000` | in MB |
-| config.cache.cache_dir | string | `"cache_dir ufs {{ $.Values.config.cache.diskDirectory }} {{ $.Values.config.cache.diskSpace }} 16 256"` | Allows full configurability of the `cache_dir` parameter. |
 | config.cache.memoryMaxSize | string | `"32 KB"` | Maximum object size to be cached in memory |
 | config.cache.memorySpace | string | `"256 MB"` | Maximum object size to be cached on disk |
 | config.cache.minSize | string | `"0 KB"` | Applies to both in-memory and on disk caches |

--- a/frontier-squid/templates/configmap.yaml
+++ b/frontier-squid/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
     # Cache management
     {{- with .Values.config.cache }}
     minimum_object_size {{ default "0 KB" .minSize }}
-    cache_dir ufs {{ default "/var/cache/squid" .diskDirectory }} {{ default "10000" .diskSpace }} 16 256
+    {{ tpl .cache_dir . }}
     maximum_object_size {{ default "1 GB" .diskMaxSize }}
     cache_mem {{ default "256 MB" .memorySpace }}
     maximum_object_size_in_memory {{ default "32 KB" .memoryMaxSize }}

--- a/frontier-squid/templates/configmap.yaml
+++ b/frontier-squid/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
     # Cache management
     {{- with .Values.config.cache }}
     minimum_object_size {{ default "0 KB" .minSize }}
-    {{ tpl .cache_dir . }}
+    {{ tpl .cache_dir $ }}
     maximum_object_size {{ default "1 GB" .diskMaxSize }}
     cache_mem {{ default "256 MB" .memorySpace }}
     maximum_object_size_in_memory {{ default "32 KB" .memoryMaxSize }}

--- a/frontier-squid/values.yaml
+++ b/frontier-squid/values.yaml
@@ -78,6 +78,8 @@ config:
     memorySpace: "256 MB"
     # -- Maximum object size to be cached in memory
     memoryMaxSize: "32 KB"
+    # -- If you need further customization of the disk cache, beyond the diskDirectory and diskSpace values.
+    cache_dir: "cache_dir ufs {{ .Values.config.cache.diskDirectory }} {{ .Values.config.cache.diskSpace }} 16 256"
 
 # -- List of squid ACLs to enable via 'http_access allow' (see configmap for ACL definitions)
 httpAccessAllow:

--- a/frontier-squid/values.yaml
+++ b/frontier-squid/values.yaml
@@ -78,7 +78,7 @@ config:
     memorySpace: "256 MB"
     # -- Maximum object size to be cached in memory
     memoryMaxSize: "32 KB"
-    # -- If you need further customization of the disk cache, beyond the diskDirectory and diskSpace values.
+    # -- For further customization of cache_dir if needed.
     cache_dir: "cache_dir ufs {{ $.Values.config.cache.diskDirectory }} {{ $.Values.config.cache.diskSpace }} 16 256"
 
 # -- List of squid ACLs to enable via 'http_access allow' (see configmap for ACL definitions)

--- a/frontier-squid/values.yaml
+++ b/frontier-squid/values.yaml
@@ -79,7 +79,7 @@ config:
     # -- Maximum object size to be cached in memory
     memoryMaxSize: "32 KB"
     # -- If you need further customization of the disk cache, beyond the diskDirectory and diskSpace values.
-    cache_dir: "cache_dir ufs {{ .Values.config.cache.diskDirectory }} {{ .Values.config.cache.diskSpace }} 16 256"
+    cache_dir: "cache_dir ufs {{ $.Values.config.cache.diskDirectory }} {{ $.Values.config.cache.diskSpace }} 16 256"
 
 # -- List of squid ACLs to enable via 'http_access allow' (see configmap for ACL definitions)
 httpAccessAllow:


### PR DESCRIPTION
Disk caches are not a good fit for squid on k8s, because any redeployment/restart results in squid wiping the disk cache (even if a PVC were used). So I want to try using RAM-only squid caches. This requires further configurability of the cache_dir parameter; it would need to be removed since the only way to use a RAM-only cache is via the squid default (i.e. cache_dir is not set) http://www.squid-cache.org/Doc/config/cache_dir/

This PR allows further configuration of cache_dir, while still allowing the cache directory and size to be configured with the values that already exist. A new cache_dir value is added, with a default that uses those other defaults.

@ebocchi can you please take a look?