### PR TITLE
frontier-squid: set default container securitycontext

### DIFF
--- a/frontier-squid/Chart.yaml
+++ b/frontier-squid/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 #
 name: frontier-squid
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: 4.17-2.1
 #
 description: Frontier Squid cache for CVMFS clients

--- a/frontier-squid/Chart.yaml
+++ b/frontier-squid/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 #
 name: frontier-squid
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: 4.17-2.1
 #
 description: Frontier Squid cache for CVMFS clients

--- a/frontier-squid/README.md
+++ b/frontier-squid/README.md
@@ -60,6 +60,7 @@ Chartmuseum format is deprecated. The last chart tag published in chartmuseum fo
 | config.cache.minSize | string | `"0 KB"` | Applies to both in-memory and on disk caches |
 | config.fileDescriptors | int | `16384` |  |
 | configFile | string | `"files/mysquid.conf"` | Squid configuration       - configFile: Provide a full configuration file.          Overrides the provided configMap only if provided and the file exists      - config: Parameters to change default valules in the provided configMap. |
+| containerSecurityContext | object | (See values) | securityContext of containers in the pod. |
 | customLabels | object | `{"component":"frontier-squid","service":"cvmfs"}` | Custom labels to identify frontier-squid pod(s).     They are used by node selection, if enabled (see above).    Label nodes accordingly to avoid scheduling problems. |
 | httpAccessAllow | list | `["stratum_ones","osgstorage","misc","grid_ca"]` | List of squid ACLs to enable via 'http_access allow' (see configmap for ACL definitions) |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |

--- a/frontier-squid/templates/deployment.yaml
+++ b/frontier-squid/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
               subPath: squid.conf
             - name: frontier-squid-disk-cache
               mountPath: {{ default "/var/cache/squid" .Values.config.cache.diskDirectory }}
+          {{- if .Values.containerSecurityContext }}
+          {{- toYaml .Values.containerSecurityContext | nindent 10 }}
+          {{- endif }}
       containers:
       - name: frontier-squid
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -78,6 +81,9 @@ spec:
             subPath: squid.conf
           - name: frontier-squid-disk-cache
             mountPath: {{ default "/var/cache/squid" .Values.config.cache.diskDirectory }}
+        {{- if .Values.containerSecurityContext }}
+        {{- toYaml .Values.containerSecurityContext | nindent 8 }}
+        {{- endif }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}

--- a/frontier-squid/templates/deployment.yaml
+++ b/frontier-squid/templates/deployment.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   replicas: {{ default 1 .Values.replicas }}
   selector:
-   matchLabels:
-     {{- include "frontier-squid.selectorLabels" . | nindent 6 }}
+    matchLabels:
+      {{- include "frontier-squid.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:

--- a/frontier-squid/templates/deployment.yaml
+++ b/frontier-squid/templates/deployment.yaml
@@ -47,7 +47,8 @@ spec:
             - name: frontier-squid-disk-cache
               mountPath: {{ default "/var/cache/squid" .Values.config.cache.diskDirectory }}
           {{- if .Values.containerSecurityContext }}
-          {{- toYaml .Values.containerSecurityContext | nindent 10 }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           {{- end }}
       containers:
       - name: frontier-squid
@@ -82,7 +83,8 @@ spec:
           - name: frontier-squid-disk-cache
             mountPath: {{ default "/var/cache/squid" .Values.config.cache.diskDirectory }}
         {{- if .Values.containerSecurityContext }}
-        {{- toYaml .Values.containerSecurityContext | nindent 8 }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 10 }}
         {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/frontier-squid/templates/deployment.yaml
+++ b/frontier-squid/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               mountPath: {{ default "/var/cache/squid" .Values.config.cache.diskDirectory }}
           {{- if .Values.containerSecurityContext }}
           {{- toYaml .Values.containerSecurityContext | nindent 10 }}
-          {{- endif }}
+          {{- end }}
       containers:
       - name: frontier-squid
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -83,7 +83,7 @@ spec:
             mountPath: {{ default "/var/cache/squid" .Values.config.cache.diskDirectory }}
         {{- if .Values.containerSecurityContext }}
         {{- toYaml .Values.containerSecurityContext | nindent 8 }}
-        {{- endif }}
+        {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}

--- a/frontier-squid/values.yaml
+++ b/frontier-squid/values.yaml
@@ -19,6 +19,17 @@ resources: {}
 # -- priorityClassName, recommended for high-occupancy clusters to prioritize squid over other pods.
 priorityClassName: ""
 
+# -- securityContext for containers
+containerSecurityContext:
+  privileged: false
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  runAsNonRoot: true
+  runAsGroup: 5000
+  runAsUser: 5000
+
 # -- Assign frontier-squid pod(s) to a node with a specific label
 #    and distribute them on different nodes to avoid single points of failure.
 podAssignment:


### PR DESCRIPTION
Set a default securityContext for the frontier-squid containers.
This is how it has always been running on our clusters.

When using Kyverno this needs to be defined explicitly.

Also clean up some YAML lint.
