### PR TITLE
update default frontier-squid image to EL9

### DIFF
--- a/frontier-squid/Chart.yaml
+++ b/frontier-squid/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 #
 name: frontier-squid
 type: application
-version: 0.1.7
-appVersion: 4.17-2.1
+version: 0.1.8
+appVersion: 4.17-2.1.el9
 #
 description: Frontier Squid cache for CVMFS clients
 icon: https://upload.wikimedia.org/wikipedia/fr/b/b7/Squid-cache_logo.jpg

--- a/frontier-squid/README.md
+++ b/frontier-squid/README.md
@@ -2,7 +2,7 @@
 
 The Helm chart for the frontier-squid proxy
 
-![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.17-2.1.el9](https://img.shields.io/badge/AppVersion-4.17--2.1.el9-informational?style=flat-square)
+![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.17-2.1.el9](https://img.shields.io/badge/AppVersion-4.17--2.1.el9-informational?style=flat-square)
 
 ### Deploy
 The chart can be installed via Helm with

--- a/frontier-squid/README.md
+++ b/frontier-squid/README.md
@@ -2,7 +2,7 @@
 
 The Helm chart for the frontier-squid proxy
 
-![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.17-2.1](https://img.shields.io/badge/AppVersion-4.17--2.1-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.17-2.1.el9](https://img.shields.io/badge/AppVersion-4.17--2.1.el9-informational?style=flat-square)
 
 ### Deploy
 The chart can be installed via Helm with

--- a/frontier-squid/schema.yaml
+++ b/frontier-squid/schema.yaml
@@ -8,7 +8,7 @@ properties:
     type: object
     required:
     - repository
-    - tag
+    # - tag
     - pullPolicy
     properties:
       repository:
@@ -20,8 +20,8 @@ properties:
         - Always
         - Never
         - IfNotPresent
-      tag:
-        type: string
+      #tag:
+        #type: string
   replicas:
     type: integer
   priorityClassName:

--- a/frontier-squid/templates/deployment.yaml
+++ b/frontier-squid/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       initContainers:
         - name: frontier-squid-init0-makedirs
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
           command: ["/usr/sbin/squid", "-f", "/etc/squid/squid.conf", "-N", "-z"]
           volumeMounts:
@@ -52,7 +52,7 @@ spec:
           {{- end }}
       containers:
       - name: frontier-squid
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         command: ["/usr/sbin/squid", "-f", "/etc/squid/squid.conf", "-N", "-d1"]
         resources: {{- .Values.resources | toYaml | nindent 10 }}

--- a/frontier-squid/values.yaml
+++ b/frontier-squid/values.yaml
@@ -2,7 +2,7 @@ image:
   # -- Docker image for the frontier squid image
   repository: gitlab-registry.cern.ch/sciencebox/docker-images/frontier-squid
   # -- Override image tag for frontier squid image if needed. Default is chart AppVersion.
-  #tag:
+  # tag:
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/frontier-squid/values.yaml
+++ b/frontier-squid/values.yaml
@@ -2,7 +2,7 @@ image:
   # -- Docker image for the frontier squid image
   repository: gitlab-registry.cern.ch/sciencebox/docker-images/frontier-squid
   # -- Override image tag for frontier squid image if needed. Default is chart AppVersion.
-  # tag:
+  tag:
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/frontier-squid/values.yaml
+++ b/frontier-squid/values.yaml
@@ -1,8 +1,8 @@
 image:
   # -- Docker image for the frontier squid image
   repository: gitlab-registry.cern.ch/sciencebox/docker-images/frontier-squid
-  # -- image tag for frontier squid image
-  tag: 4.17-2.1
+  # -- Override image tag for frontier squid image if needed. Default is chart AppVersion.
+  #tag:
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
- Update chart version to 0.1.8
- Update app version from 4.17-2.1 to 4.17-2.1.el9
- Use new [EL9 squid image](https://github.com/sciencebox/frontier-squid/pull/1#issuecomment-2259380898) by default
- Change image tag to use chart appVersion by default